### PR TITLE
Update _redirects

### DIFF
--- a/content/_redirects
+++ b/content/_redirects
@@ -2,7 +2,7 @@
 # For more info, see https://www.netlify.com/docs/redirects/
 
 # Redirect default Netlify subdomain to primary domain
-https://elated-haibt-1b47ff.netlify.com/* https://opencue.io/:splat 301!
+https://elated-haibt-1b47ff.netlify.com/* https://www.opencue.io/:splat 301!
 
 # Handle 404 errors
 # For more info, see https://www.netlify.com/docs/redirects/#custom-404

--- a/content/_redirects
+++ b/content/_redirects
@@ -1,6 +1,9 @@
 # Redirects for opencue.io
 # For more info, see https://www.netlify.com/docs/redirects/
 
+# Redirect default Netlify subdomain to primary domain
+https://elated-haibt-1b47ff.netlify.com/* https://opencue.io/:splat 301!
+
 # Handle 404 errors
 # For more info, see https://www.netlify.com/docs/redirects/#custom-404
 


### PR DESCRIPTION
Netlify suggests adding a redirect from the default subdomain to the live site to improve SEO.

This PR isn't practical to preview / test live, so instead I tested it using the [Netlify redirect playground](https://play.netlify.com/redirects), which produces the following output:

Yay! All redirects are valid
```
[[redirects]]
from = "https://elated-haibt-1b47ff.netlify.com/*"
to = "https://opencue.io/:splat"
status = 301
force = true
```