### PR TITLE
Build script

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   publish = "public"
-  command = "hugo"
+  command = "./scripts/build.sh"
 
 [context.deploy-preview.environment]
   HUGO_VERSION = "0.54.0"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Fetch the currently configured version of the Hugo theme (Docsy)
+git submodule update --init --recursive
+
+# Build the site
+hugo

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-# Fetch the currently configured version of the Hugo theme (Docsy)
+# The Hugo theme (Docsy) is configured as a submodule.
+# Recursively update and initilaize all Git submodules.
 git submodule update --init --recursive
 
 # Build the site


### PR DESCRIPTION
Replace the default build command to deploy the site with a shell script.

Currently Netlify is configured to simply run the command `hugo` when deploying the site, which builds the HTML from the source Markdown.

This change updates the Netlify configuration to deploy the site using a shell script `scripts/build.sh`.

`build.sh` simply updates and initializes the Docsy Git submodule and then runs the `hugo` command. 

In subsequent PRs we can expand the work of the `build.sh` script to manipulate content for publishing, such as pulling the CONTRIBUTING.md file from the OpenCue repository, generating API reference docs (JavaDoc and PyDoc), and other automated changes.