### PR TITLE
Update config.toml

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -103,10 +103,10 @@ breadcrumb_disable = false
 # If you want this feature, but occasionally need to remove the "Feedback" section from a single page,
 # add "hide_feedback: true" to the page's front matter.
 [params.ui.feedback]
-enable = false
+enable = true
 # The responses that the user sees after clicking "yes" (the page was helpful) or "no" (the page was not helpful).
-yes = 'Glad to hear it! Please <a href="https://github.com/USERNAME/REPOSITORY/issues/new">tell us how we can improve</a>.'
-no = 'Sorry to hear that. Please <a href="https://github.com/USERNAME/REPOSITORY/issues/new">tell us how we can improve</a>.'
+yes = 'Glad to hear it! Please <a href="https://github.com/AcademySoftwareFoundation/opencue.io/issues/new">tell us how we can improve</a>.'
+no = 'Sorry to hear that. Please <a href="https://github.com/AcademySoftwareFoundation/opencue.io/issues/new">tell us how we can improve</a>.'
 
 [params.links]
 # End user relevant links. These will show up on left side of footer and in the community page if you have one.


### PR DESCRIPTION
Turn on the feature to collect feedback from visitors about whether or not the current page is helpful, along with a link to create issues for more details.

Please see `config.toml` for more details about how this works.

The feedback widget appears on all docs pages, but not the home or blog pages.

To see a preview of the widget, see:

https://5d495ac7c5ec8c000894da64--elated-haibt-1b47ff.netlify.com/docs/concepts/

Fixes https://github.com/AcademySoftwareFoundation/opencue.io/issues/66