### PR TITLE
Adding a doc page about applying migrations to an existing database.

### DIFF
--- a/content/docs/Other guides/applying-database-migrations.md
+++ b/content/docs/Other guides/applying-database-migrations.md
@@ -1,0 +1,34 @@
+---
+title: "Applying database migrations"
+linkTitle: "Applying database migrations"
+weight: 1
+date: 2019-08-22
+description: >
+  How to apply new database migrations
+---
+
+This page describes how to apply new database migrations when necessary.
+
+## What is a database migration and why do I need one
+
+Occasionally developers will make code changes that require the database schema to be updated. When
+this happens the schema changes will be added as a new "migration". The migration contains raw SQL
+and only the parts of the schema that have changed. The migration can be applied and safely rolled
+back using the database management tool of your choice. This example uses
+[flyway](https://flywaydb.org/).
+
+When updating Cuebot it is important to apply any new migrations to ensure the Cuebot code matches
+the correct database schema. These changes will also be flagged in the release notes.
+
+To apply a migration:
+
+1. Stop Cuebot, by either killing the Cuebot process or stopping its container.
+
+1. Run the `flyway` command to execute the migrations, using the credentials from the original
+[database installation](/docs/getting-started/setting-up-the-database). Run this from the root
+folder of the OpenCue repo.
+    ```shell
+    flyway -url=jdbc:postgresql://$DB_HOST/$DB_NAME -user=$USER -n -locations=filesystem:cuebot/src/main/resources/conf/ddl/postgres/migrations migrate
+    ``` 
+
+1. Restart Cuebot.

--- a/content/docs/Other guides/applying-database-migrations.md
+++ b/content/docs/Other guides/applying-database-migrations.md
@@ -24,11 +24,13 @@ To apply a migration:
 
 1. Stop Cuebot, by either killing the Cuebot process or stopping its container.
 
-1. Run the `flyway` command to execute the migrations, using the credentials from the original
+. Run the `flyway` command to execute the migrations, using the credentials from the original
 [database installation](/docs/getting-started/setting-up-the-database). Run this from the root
 folder of the OpenCue repo.
     ```shell
     flyway -url=jdbc:postgresql://$DB_HOST/$DB_NAME -user=$USER -n -locations=filesystem:cuebot/src/main/resources/conf/ddl/postgres/migrations migrate
     ``` 
+
+1. Update Cuebot by following the installation instructions on [Deploying Cuebot](/docs/getting-started/deploying-cuebot).
 
 1. Restart Cuebot.


### PR DESCRIPTION
Adding a specific doc page about database migrations. This is briefly covered in the setting up the database section, but I thought it deserved its own page since this is also a maintenance process when applying updates.