### PR TITLE
Add a blog post with BoF recording

### DIFF
--- a/content/blog/news/roadmap-july-2019-recording.md
+++ b/content/blog/news/roadmap-july-2019-recording.md
@@ -22,5 +22,5 @@ The Birds of a Feather session included the following topics and sections:
 
 {{% alert title="Note" color="info"%}}Approximately the first 15 minutes of
 questions aren't audible on the recording but the answers are recorded and
-captioned. From approximately 23 minutes into the recording the questions are
+captioned. From approximately 23 minutes into the recording, the questions are
 audible.{{% /alert %}}

--- a/content/blog/news/roadmap-july-2019-recording.md
+++ b/content/blog/news/roadmap-july-2019-recording.md
@@ -1,0 +1,26 @@
+---
+title: "OpenCue at SIGGRAPH recording"
+linkTitle: "OpenCue at SIGGRAPH recording"
+date: 2019-09-20
+description: "Watch a recording of the OpenCue Birds of a Feather roadmap from SIGGRAPH 2019"
+---
+
+The Academy Software Foundation recently published the following recording of
+the OpenCue Birds of a Feather session at SIGGRAPH 2019:
+
+<div class="w-75 mx-auto embed-responsive embed-responsive-16by9 mb-3">
+    <iframe class="embed-responsive-item" width="560" height="315" src="https://www.youtube-nocookie.com/embed/0gXT3sntiFg" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+
+The Birds of a Feather session included the following topics and sections:
+
+* Todd Prives (Google) introduced the session.
+* Ben Dines (Sony Pictures Imageworks) gave a summary of the development and
+  use of Cue3 on a number of films.
+* Brian Cipriano (Google) provided an overview of the development roadmap for OpenCue.
+* The team answered questions from the audience for the remainder of the session.
+
+{{% alert title="Note" color="info"%}}Approximately the first 15 minutes of
+questions aren't audible on the recording but the answers are recorded and
+captioned. From approximately 23 minutes into the recording the questions are
+audible.{{% /alert %}}


### PR DESCRIPTION
Adds a blog post for the BoF recording from SIGGRAPH 2019.

Staged at:

https://deploy-preview-102--elated-haibt-1b47ff.netlify.com/blog/2019/09/20/opencue-at-siggraph-recording/

(I came across this by accident, so thought it would be worth promoting on the blog as it's not very prominent in search results yet.)