### PR TITLE
Add quick start for linux

### DIFF
--- a/content/docs/Quick starts/quick-start-linux.md
+++ b/content/docs/Quick starts/quick-start-linux.md
@@ -1,10 +1,10 @@
 ---
-title: "Quick start for macOS"
-linkTitle: "Quick start for macOS"
-weight: 2
-date: 2019-09-04
+title: "Quick start for Linux"
+linkTitle: "Quick start for Linux"
+weight: 1
+date: 2019-09-020
 description: >
-  Try OpenCue in the sandbox environment on macOS
+  Try OpenCue in the sandbox environment on Linux
 ---
 
 OpenCue is an open source render management system. You can use
@@ -30,12 +30,7 @@ You must have the following software installed on your machine:
 *   [Docker](https://docs.docker.com/install/)
 *   [Docker Compose](https://docs.docker.com/compose/install/)
 
-{{% alert title="Note" color="info"%}}Docker compose is included in the
-desktop installation of Docker on macOS.{{% /alert %}}
-
-You must allocate a minimum of 6 GB of memory to Docker. To learn
-how to update the memory limit on macOS, see
-[Get started with Docker Desktop for Mac](https://docs.docker.com/docker-for-mac/#advanced).
+You must allocate a minimum of 6 GB of memory to Docker.
 
 If you don't already have a recent local copy of the OpenCue source code, you
 must do one of the following:
@@ -72,7 +67,21 @@ with the `docker-compose` command.
 
 To deploy the OpenCue sandbox environment:
 
-1.  Start the Terminal app.
+1.  Open a Terminal window.
+
+1.  If you haven't already, add your user account to the `docker` group:
+
+        sudo gpasswd -a $USER docker
+
+1.  Docker Compose mounts the logging volume for the RQD rendering server on
+    the host operating system under `/tmp/rqd/logs`. To create the mount point
+    with the required permissions, run the following command:
+
+    {{% alert title="Note" color="info"%}}If you skip this step, the root
+    account of the host operating system might incorrectly own the mount point
+    directory.{{% /alert %}}
+
+        mkdir -p /tmp/rqd/logs
 
 1.  Change to the root of the OpenCue source code directory:
 
@@ -167,7 +176,7 @@ Terminal window:
 
 2.  The Cuebot docker container is forwarding the gRPC ports to your
     localhost, so you can connect to it as `localhost`:
-    
+
         export CUEBOT_HOSTS=localhost
 
 3.  To verify the successful installation of the sandbox environment, as well

--- a/content/docs/Quick starts/quick-start-linux.md
+++ b/content/docs/Quick starts/quick-start-linux.md
@@ -30,15 +30,13 @@ You must have the following software installed on your machine:
 *   [Docker](https://docs.docker.com/install/)
 *   [Docker Compose](https://docs.docker.com/compose/install/)
 
-You must allocate a minimum of 6 GB of memory to Docker.
-
 If you don't already have a recent local copy of the OpenCue source code, you
 must do one of the following:
 
 1.  Download and unzip the
     [OpenCue source code ZIP file](https://github.com/AcademySoftwareFoundation/OpenCue/archive/master.zip).
 
-1.  If you have the `git` command installed on your machine, you can clone
+2.  If you have the `git` command installed on your machine, you can clone
     the repository:
 
         git clone https://github.com/AcademySoftwareFoundation/OpenCue.git
@@ -69,11 +67,11 @@ To deploy the OpenCue sandbox environment:
 
 1.  Open a Terminal window.
 
-1.  If you haven't already, add your user account to the `docker` group:
+2.  If you haven't already, add your user account to the `docker` group:
 
         sudo gpasswd -a $USER docker
 
-1.  Docker Compose mounts the logging volume for the RQD rendering server on
+3.  Docker Compose mounts the logging volume for the RQD rendering server on
     the host operating system under `/tmp/rqd/logs`. To create the mount point
     with the required permissions, run the following command:
 
@@ -83,11 +81,11 @@ To deploy the OpenCue sandbox environment:
 
         mkdir -p /tmp/rqd/logs
 
-1.  Change to the root of the OpenCue source code directory:
+4.  Change to the root of the OpenCue source code directory:
 
         cd OpenCue
 
-2.  To deploy the OpenCue sandbox environment, export the `CUE_FRAME_LOG_DIR`
+5.  To deploy the OpenCue sandbox environment, export the `CUE_FRAME_LOG_DIR`
     environment variable:
 
     {{% alert title="Note" color="info"%}}You must export all environment
@@ -95,12 +93,12 @@ To deploy the OpenCue sandbox environment:
 
         export CUE_FRAME_LOG_DIR=/tmp/rqd/logs
 
-3.  To specify a password for the database, export the `POSTGRES_PASSWORD`
+6.  To specify a password for the database, export the `POSTGRES_PASSWORD`
     environment variable:
 
         export POSTGRES_PASSWORD=<REPLACE-WITH-A-PASSWORD>
 
-4.  To deploy the sandbox environment, run the `docker-compose` command:
+7.  To deploy the sandbox environment, run the `docker-compose` command:
 
         docker-compose --project-directory . -f sandbox/docker-compose.yml up
 


### PR DESCRIPTION
Adds a quick start for Linux operating systems. I don't think there's anything in this quick start or the associated sandbox scripts and resources that is specific to a particular distribution of Linux.

This guide differs from the macOS version in a few ways:

- Updated title and description
- Updated requirements
- Additional steps to add $USER to the docker group and create the mount point

I'll follow up with a PR to update the call to action on the home page to point at the quick starts index.

Staged at:

https://deploy-preview-104--elated-haibt-1b47ff.netlify.com/docs/quick-starts/

I might also try to single-source some of the writing in the quick starts if time permits.