### PR TITLE
Add meta description

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -87,6 +87,7 @@ time_format_blog = "Monday, January 2, 2006"
 # Everything below this are Site Params
 
 [params]
+description = "OpenCue is an open source render management system."
 copyright = "Copyright Contributors to the OpenCue Project"
 privacy_policy = "https://lfprojects.org/policies/privacy-policy/"
 github_repo = "https://github.com/AcademySoftwareFoundation/opencue.io"

--- a/content/_index.html
+++ b/content/_index.html
@@ -6,7 +6,7 @@ linkTitle = "OpenCue"
 
 {{< blocks/cover title="OpenCue" image_anchor="top" height="max">}}
 <div class="mx-auto">
-	<p class="lead">Open source render management</p>
+	<p class="lead">An open source render management system</p>
 	<a class="btn btn-lg btn-primary mr-3 ml-3 mt-3 mb-5" href="/docs/getting-started/">
 		Get started <i class="fas fa-arrow-alt-circle-right ml-1"></i>
 	</a>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,0 +1,27 @@
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+{{ hugo.Generator }}
+{{ if eq (getenv "HUGO_ENV") "production" }}
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+{{ else }}
+<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+{{ end }}
+<meta name="description" content="{{if .IsHome}}{{ $.Site.Params.description }}{{else}}{{.Description}}{{end}}" />
+{{ range .AlternativeOutputFormats -}}
+<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
+{{ end -}}
+{{ partialCached "favicons.html" . }}
+<title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
+{{- template "_internal/opengraph.html" . -}}
+{{- template "_internal/google_news.html" . -}}
+{{- template "_internal/schema.html" . -}}
+{{- template "_internal/twitter_cards.html" . -}}
+{{ if eq (getenv "HUGO_ENV") "production" }}
+{{ template "_internal/google_analytics_async.html" . }}
+{{ end }}
+{{ partialCached "head-css.html" . "asdf" }}
+<script
+  src="https://code.jquery.com/jquery-3.3.1.min.js"
+  integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
+  crossorigin="anonymous"></script>
+{{ partial "hooks/head-end.html" . }}


### PR DESCRIPTION
Adds a meta description to the site. The Docsy head.html partial template is missing the meta description, so this adds it for opencue.io. Hopefully, this will resolve #107, and if it does then I'll contribute the fix back to Docsy.

Regardless, I've run the Lighthouse SEO audit in Chrome and found that this change increases the SEO score from 80 to 90 %.

Signed-off-by: Sharif Salah <sharifsalah@google.com>