### PR TITLE
Add site verification file

### DIFF
--- a/static/google1754895143f2ffa0.html
+++ b/static/google1754895143f2ffa0.html
@@ -1,0 +1,1 @@
+google-site-verification: google1754895143f2ffa0.html


### PR DESCRIPTION
Adds a site HTML verification file to allow access to the Google Search Console as described in the following support page:

https://support.google.com/webmasters/answer/9008080#html_verification

This should help me diagnose and verify that Google is indexing the site correctly. (Most other search engines are).

After verification, I'll share access to the console with other team members.

Signed-off-by: Sharif Salah <sharifsalah@google.com>