### PR TITLE
Fix code formatting in alert block.

### DIFF
--- a/content/docs/Getting started/setting-up-the-database.md
+++ b/content/docs/Getting started/setting-up-the-database.md
@@ -197,9 +197,10 @@ To create a database:
     the following similar command to grant privileges on all **existing**
     tables:
 
-    ```shell
-    psql -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO $DB_USER" $DB_NAME
-    ```
+      ```shell
+      psql -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO $DB_USER" $DB_NAME
+      ```
+
     {{% /alert %}}
 
 ## Populate the database

--- a/content/docs/Getting started/setting-up-the-database.md
+++ b/content/docs/Getting started/setting-up-the-database.md
@@ -197,9 +197,7 @@ To create a database:
     the following similar command to grant privileges on all **existing**
     tables:
 
-      ```shell
-      psql -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO $DB_USER" $DB_NAME
-      ```
+    psql -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO $DB_USER" $DB_NAME
 
     {{% /alert %}}
 


### PR DESCRIPTION
Before:
<img width="875" alt="Screen Shot 2020-01-28 at 3 44 09 PM" src="https://user-images.githubusercontent.com/2013647/73315486-15f64a00-41e5-11ea-8182-16b300617f86.png">

After:
<img width="861" alt="Screen Shot 2020-01-28 at 3 44 01 PM" src="https://user-images.githubusercontent.com/2013647/73315487-168ee080-41e5-11ea-80bc-a1c5f59a0bf9.png">

I think this might be a Docsy bug because in the "after" version, there's no indication that our `psql` line should actually be a codeblock. I think the default "anything indented is a codeblock" styling should be overridden by the active `alert` block, but that isn't happening here.

@sharifsalah WDYT?
