### PR TITLE
Update Hugo version number for development and production

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -54,11 +54,16 @@ pygmentsStyle = "tango"
 blog = "/:section/:year/:month/:day/:slug/"
 
 ## Configuration for BlackFriday markdown parser: https://github.com/russross/blackfriday
-[blackfriday]
-plainIDAnchors = true
-hrefTargetBlank = true
-angledQuotes = false
-latexDashes = true
+# [blackfriday]
+# plainIDAnchors = true
+# hrefTargetBlank = true
+# angledQuotes = false
+# latexDashes = true
+
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true
 
 # Image processing configuration.
 [imaging]

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,5 +7,5 @@
   HUGO_ENV = "development"
 
 [context.production.environment]
-  HUGO_VERSION = "0.54.0"
+  HUGO_VERSION = "0.63.2"
   HUGO_ENV = "production"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   command = "./scripts/build.sh"
 
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.54.0"
+  HUGO_VERSION = "0.63.2"
   HUGO_ENV = "development"
 
 [context.production.environment]


### PR DESCRIPTION
Update the version number of the Hugo framework we use to deploy to preview and production. Also update to the latest version of the Docsy theme.

Although, there aren't many code changes in this PR, the impact is rather wide.

I understand from the Docsy team that versions of Hugo newer than 0.6.0 include a new Markdown processor (Goldmark).

The only worthwhile visual change I've noticed is that Goldmark seems to render whitespace after list bullets differently from the old Markdown processor (Blackfriday), usually resulting in more white space.

I've also updated the configuration of Hugo to allow HTML embedded in Markdown.

From the Netlify deploy log:

```
3:48:00 PM: Installing Hugo 0.63.2
3:48:01 PM: Hugo Static Site Generator v0.63.2-934EE21F linux/amd64 BuildDate: 2020-01-27T12:13:19Z
```

Staged at:

https://5e31a91b72ef6d0008e4ab8b--elated-haibt-1b47ff.netlify.com/