### PR TITLE
Clarify CUE_FS_ROOT and fix for macOS.

### DIFF
--- a/content/docs/Getting started/deploying-cuebot.md
+++ b/content/docs/Getting started/deploying-cuebot.md
@@ -87,16 +87,17 @@ Make sure you also complete the following steps:
 1.  Cuebot needs to know the location of the filesystem where render assets
     are stored and log files are written. In a large-scale deployment a shared
     filesystem such as NFS is often used for this purpose. For the purposes of
-    this tutorial, you can use any directory you have write access to.
+    this guide, you can use any directory you have write access to.
 
     ```shell
-    export CUE_FS_ROOT="$HOME/opencue-tutorial"
+    export CUE_FS_ROOT="$HOME/opencue-demo"
     mkdir -p "$CUE_FS_ROOT"
     ```
 
     If you plan to run [CueGUI](/docs/getting-started/installing-cuegui) and
-    [CueSubmit](/docs/getting-started/installing-cuesubmit) on the same host,
-    all components can use the local filesystem for this purpose.
+    [CueSubmit](/docs/getting-started/installing-cuesubmit) on the same host
+    as Cuebot, then all three components can use the local filesystem on that
+    host.
 
 ## Installing and running Cuebot
 

--- a/content/docs/Getting started/deploying-cuebot.md
+++ b/content/docs/Getting started/deploying-cuebot.md
@@ -84,6 +84,20 @@ Make sure you also complete the following steps:
     to the database. This configuration is outside of the scope of this
     guide.{{% /alert %}}
 
+1.  Cuebot needs to know the location of the filesystem where render assets
+    are stored and log files are written. In a large-scale deployment a shared
+    filesystem such as NFS is often used for this purpose. For the purposes of
+    this tutorial, you can use any directory you have write access to.
+
+    ```shell
+    export CUE_FS_ROOT="$HOME/opencue-tutorial"
+    mkdir -p "$CUE_FS_ROOT"
+    ```
+
+    If you plan to run [CueGUI](/docs/getting-started/installing-cuegui) and
+    [CueSubmit](/docs/getting-started/installing-cuesubmit) on the same host,
+    all components can use the local filesystem for this purpose.
+
 ## Installing and running Cuebot
 
 ### Option 1: Download and run the pre-built Docker image from DockerHub
@@ -99,7 +113,7 @@ To download and run the Cuebot Docker image:
 1.  To start Cuebot, run the Docker image:
 
     ```shell
-    docker run -td --name cuebot -p 8080:8080 -p 8443:8443 opencue/cuebot --datasource.cue-data-source.jdbc-url=jdbc:postgresql://$DB_HOST_IN_DOCKER/$DB_NAME --datasource.cue-data-source.username=$DB_USER --datasource.cue-data-source.password=$DB_PASS
+    docker run -td --name cuebot -p 8080:8080 -p 8443:8443 opencue/cuebot --datasource.cue-data-source.jdbc-url=jdbc:postgresql://$DB_HOST_IN_DOCKER/$DB_NAME --datasource.cue-data-source.username=$DB_USER --datasource.cue-data-source.password=$DB_PASS  --log.frame-log-root="${CUE_FS_ROOT}/logs"
     ```
 
 ### Option 2: Build and run the Cuebot Docker image from source
@@ -119,7 +133,7 @@ To build and run the Cuebot Docker image:
 1.  To start Cuebot, run the Docker image:
 
     ```shell
-    docker run -td --name cuebot -p 8080:8080 -p 8443:8443 opencue/cuebot --datasource.cue-data-source.jdbc-url=jdbc:postgresql://$DB_HOST_IN_DOCKER/$DB_NAME --datasource.cue-data-source.username=$DB_USER --datasource.cue-data-source.password=$DB_PASS
+    docker run -td --name cuebot -p 8080:8080 -p 8443:8443 opencue/cuebot --datasource.cue-data-source.jdbc-url=jdbc:postgresql://$DB_HOST_IN_DOCKER/$DB_NAME --datasource.cue-data-source.username=$DB_USER --datasource.cue-data-source.password=$DB_PASS --log.frame-log-root="${CUE_FS_ROOT}/logs"
     ```
 
 ### Option 3: Manually install from the published release
@@ -147,7 +161,7 @@ from the latest release's Assets.
 
     ```shell
     export JAR_PATH=<path to Cuebot JAR>
-    java -jar $JAR_PATH --datasource.cue-data-source.jdbc-url=jdbc:postgresql://$DB_HOST/$DB_NAME --datasource.cue-data-source.username=$DB_USER --datasource.cue-data-source.password=$DB_PASS
+    java -jar $JAR_PATH --datasource.cue-data-source.jdbc-url=jdbc:postgresql://$DB_HOST/$DB_NAME --datasource.cue-data-source.username=$DB_USER --datasource.cue-data-source.password=$DB_PASS --log.frame-log-root="${CUE_FS_ROOT}/logs"
     ```
 
 ### Option 4: Build from source
@@ -183,7 +197,7 @@ and your current directory is the root of the checked out source.
 1.  Finally, use your JRE to run the Cuebot JAR:
 
     ```shell
-    java -jar build/libs/cuebot-all.jar --datasource.cue-data-source.jdbc-url=jdbc:postgresql://$DB_HOST/$DB_NAME --datasource.cue-data-source.username=$DB_USER --datasource.cue-data-source.password=$DB_PASS
+    java -jar build/libs/cuebot-all.jar --datasource.cue-data-source.jdbc-url=jdbc:postgresql://$DB_HOST/$DB_NAME --datasource.cue-data-source.username=$DB_USER --datasource.cue-data-source.password=$DB_PASS --log.frame-log-root="${CUE_FS_ROOT}/logs"
     ```
 
 ## Verifying your install

--- a/content/docs/Getting started/deploying-rqd.md
+++ b/content/docs/Getting started/deploying-rqd.md
@@ -39,7 +39,7 @@ Make sure you also complete the following steps:
     -   **If you also installed Cuebot in a container**, fetch the container IP:
 
         ```shell
-        export CUEBOT_HOSTNAME=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' <name of Cuebot container>)
+        export CUEBOT_HOSTNAME=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' cuebot)
         ```
 
     -   **If your Cuebot is running on a different machine**, use that machine's
@@ -57,7 +57,7 @@ Make sure you also complete the following steps:
     define `CUE_FS_ROOT` and ensure the directory exists:
 
     ```shell
-    CUE_FS_ROOT=/shots
+    export CUE_FS_ROOT="${HOME}/opencue-tutorial"
     mkdir -p "$CUE_FS_ROOT"
     ```
 

--- a/content/docs/Getting started/deploying-rqd.md
+++ b/content/docs/Getting started/deploying-rqd.md
@@ -57,7 +57,7 @@ Make sure you also complete the following steps:
     define `CUE_FS_ROOT` and ensure the directory exists:
 
     ```shell
-    export CUE_FS_ROOT="${HOME}/opencue-tutorial"
+    export CUE_FS_ROOT="${HOME}/opencue-demo"
     mkdir -p "$CUE_FS_ROOT"
     ```
 


### PR DESCRIPTION
Fixes #148 

- Specify a new location for logs to be written. The default locations of `/shots` no longer works on macOS.
  - This also has the side effect of demonstrating this feature for the user, which is extremely helpful when figuring out how to create an actual production deployment.
- Maintaining the concept of `CUE_FS_ROOT`, write logs into a `logs/` subdirectory. In the event a user uses their actual NFS for this, we don't want to pollute that directory with a bunch of project folders. IMO it's obvious enough how you could adapt your actual project directory structure to match this, once you see the directory structure that gets created in `logs/`.
