### PR TITLE
Fixes Error : 404 Page not found

### DIFF
--- a/content/docs/Quick starts/quick-start-linux.md
+++ b/content/docs/Quick starts/quick-start-linux.md
@@ -44,7 +44,7 @@ must do one of the following:
 ## Deploying the OpenCue sandbox environment
 
 You deploy the sandbox environment using
-[Docker Compose]([https://docs.docker.com/compose/]), which downloads and runs
+[Docker Compose](https://docs.docker.com/compose/), which downloads and runs
 the images of the following containers from Docker Hub:
 
 *   a PostgresSQL database


### PR DESCRIPTION
Under the section Deploying the OpenCue sandbox environment, On opening docker compose raises an error such as:
 Sorry, we couldn't find that page.
You can try any of the following instead: