### PR TITLE
Fixes Error : 404 Page not found

### DIFF
--- a/content/docs/Quick starts/quick-start-mac.md
+++ b/content/docs/Quick starts/quick-start-mac.md
@@ -56,7 +56,7 @@ must do one of the following:
 ## Deploying the OpenCue sandbox environment
 
 You deploy the sandbox environment using
-[Docker Compose]([https://docs.docker.com/compose/]), which runs the
+[Docker Compose](https://docs.docker.com/compose/), which runs the
 following containers:
 
 *   a PostgresSQL database


### PR DESCRIPTION
Under the section Deploying the OpenCue sandbox environment, On opening docker compose raises an error such as:
Sorry, we couldn't find that page.
You can try any of the following instead: