### PR TITLE
Add a note about configuring PyCharm

### DIFF
--- a/content/contributing/opencue/Getting started/getting-started-mac.md
+++ b/content/contributing/opencue/Getting started/getting-started-mac.md
@@ -208,6 +208,12 @@ containing all of the Python components. PyCharm is used here.
    - `pycue/`
    - `pyoutline/`
    - `rqd/`
+   
+1. To set docstring format to **reStructuredText** :
+    ```
+    Tools > Python Integrated Tools > Docstrings > Docstring format to  "reStructuredText".
+    ```
+    This will let you use standard PyCharm tools for generating docstrings in this format.
 
 ## Generate gRPC Python code
 

--- a/content/contributing/opencue/build-docs.md
+++ b/content/contributing/opencue/build-docs.md
@@ -161,3 +161,11 @@ HTML output:
 ```
 make clean
 ```
+
+## Note about configuring PyCharm
+
+For anyone using PyCharm, they can set docstring format to **reStructuredText** by following this:
+```
+Tools > Python Integrated Tools > Docstrings > Docstring format to  "reStructuredText".
+```
+This will let you use standard PyCharm tools for generating docstrings in this format.


### PR DESCRIPTION
Fixes #143 
Adds PyCharm configuration for docstring formatting to the contributor guide for the API reference docs.