### PR TITLE
Update _index.html

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -14,7 +14,7 @@ linkTitle = "OpenCue"
 		Contribute <i class="fab fa-github ml-1"></i>
 	</a>
 	<div class="w-75 mx-auto embed-responsive embed-responsive-16by9 mb-3">
-		<iframe class="embed-responsive-item" width="560" height="315" src="https://www.youtube-nocookie.com/embed/8z61RZhvKQ8" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+		<iframe class="embed-responsive-item" width="560" height="315" src="https://www.youtube-nocookie.com/embed/jPpBcHCMlA4" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 	</div>
 	{{< blocks/link-down color="primary" >}}
 </div>


### PR DESCRIPTION
https://github.com/AcademySoftwareFoundation/opencue.io/issues/200

Update the embedded project reel on the landing page to the 2020 version.

Note: the thumbnail is a bit confusing as it includes the OpenColorIO logo...

Staged at:
https://deploy-preview-199--elated-haibt-1b47ff.netlify.app/
