### PR TITLE
Streamlined setting up a local instance of documentation using Hugo

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ To set up a local copy of the OpenCue website:
 
 1. Make sure NPM (Node Package Manager) is installed on your system.
 
-1.  Install Hugo for your system from [here](https://github.com/gohugoio/hugo/releases).
+1.  Follow these steps to [install Hugo](https://gohugo.io/getting-started/installing/) for your operating system.
+    Or, you can follow these steps to [install from binaries](https://github.com/gohugoio/hugo/releases).
 
 1.  Clone the opencue.io repository:
 
@@ -77,13 +78,13 @@ To set up a local copy of the OpenCue website:
     npm install
     ```
   
-1. Install `AutoPrefixer` to parse the CSS files.
+1. Install `AutoPrefixer` to parse the CSS files:
 
     ```shell
    sudo npm install -D --save autoprefixer
      ```
 
-1. Install `PostCSS` so that the site build can create the final CSS assets.
+1. Install `PostCSS` so that the site build can create the final CSS assets:
 
     ```shell
    sudo npm install -D --save postcss-cli

--- a/README.md
+++ b/README.md
@@ -81,13 +81,13 @@ To set up a local copy of the OpenCue website:
 1. Install `AutoPrefixer` to parse the CSS files:
 
     ```shell
-   sudo npm install -D --save autoprefixer
+   npm install autoprefixer
      ```
 
 1. Install `PostCSS` so that the site build can create the final CSS assets:
 
     ```shell
-   sudo npm install -D --save postcss-cli
+   npm install postcss-cli
      ```
 
 1.  Run the `hugo` command to verify the installation steps were successful:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Netlify Status](https://api.netlify.com/api/v1/badges/bef98bd8-69d2-4c22-a49e-c1c3897638ac/deploy-status)](https://app.netlify.com/sites/elated-haibt-1b47ff/deploys)
 
 Welcome to the repository for the OpenCue documentation and website. This
-repository hosts all of the code and resources to build the OpenCue
+repository hosts all the code and resources to build the OpenCue
 documentation and website. We welcome contributions to the docs.
 
 ## Contributing to the documentation
@@ -45,6 +45,10 @@ information, see the [Docsy documentation](https://github.com/google/docsy).
 
 To set up a local copy of the OpenCue website:
 
+1. Make sure NPM (Node Package Manager) is installed on your system.
+
+1.  Install Hugo for your system from [here](https://github.com/gohugoio/hugo/releases).
+
 1.  Clone the opencue.io repository:
 
     ```shell
@@ -72,11 +76,29 @@ To set up a local copy of the OpenCue website:
     ```
     npm install
     ```
+  
+1. Install `AutoPrefixer` to parse the CSS files.
+
+    ```shell
+   sudo npm install -D --save autoprefixer
+     ```
+
+1. Install `PostCSS` so that the site build can create the final CSS assets.
+
+    ```shell
+   sudo npm install -D --save postcss-cli
+     ```
 
 1.  Run the `hugo` command to verify the installation steps were successful:
 
     ```
     hugo
+    ```
+    
+1. Run the `hugo server` command to serve the static content and view it in your browser:   
+    
+     ```
+    hugo server
     ```
     
 You can now create a Git branch in your copy of the repository to experiment


### PR DESCRIPTION
As a beginner to this project, setting up a local instance using Hugo had me some tweaks to do, so I have added changes in the readme.md file which make it very easy and simple to get a local instance running on any system from the get go.

Although all steps have been covered, they aren't at all ordered and just not the way to go for a beginner to this project, wishing to contribute.

The changes have been made keeping in mind that the new contributors to the project must have the very first step in their journey, i.e. "Setting up the local instance of the docs" easy and simple without any tweaking being needed.
