### PR TITLE
Added python-dev as a pre-req for Linux-quickstart

### DIFF
--- a/content/docs/Quick starts/quick-start-linux.md
+++ b/content/docs/Quick starts/quick-start-linux.md
@@ -27,7 +27,7 @@ You must have the following software installed on your machine:
 *   Python version 2.7 or greater
 *   The Python [`pip` command](https://pypi.org/project/pip/)
 *   The Python [virtualenv tool](https://pypi.org/project/virtualenv/)
-*   The ```python-dev``` [command](https://pypi.org/project/Python-dev/)
+*   The ```python-dev``` command 
 *   [Docker](https://docs.docker.com/install/)
 *   [Docker Compose](https://docs.docker.com/compose/install/)
 
@@ -41,6 +41,9 @@ must do one of the following:
     the repository:
 
         git clone https://github.com/AcademySoftwareFoundation/OpenCue.git
+    
+3. Make sure you have the ```python-dev package``` installed on your system corresponding to the Python version you
+have installed. 
 
 ## Deploying the OpenCue sandbox environment
 

--- a/content/docs/Quick starts/quick-start-linux.md
+++ b/content/docs/Quick starts/quick-start-linux.md
@@ -27,7 +27,7 @@ You must have the following software installed on your machine:
 *   Python version 2.7 or greater
 *   The Python [`pip` command](https://pypi.org/project/pip/)
 *   The Python [virtualenv tool](https://pypi.org/project/virtualenv/)
-*   The ```python-dev``` command 
+*   The ```python-dev``` (Ubuntu/Debian) or ```python-devel```(Fedora/Cent-OS) package 
 *   [Docker](https://docs.docker.com/install/)
 *   [Docker Compose](https://docs.docker.com/compose/install/)
 
@@ -41,9 +41,7 @@ must do one of the following:
     the repository:
 
         git clone https://github.com/AcademySoftwareFoundation/OpenCue.git
-    
-3. Make sure you have the ```python-dev package``` installed on your system corresponding to the Python version you
-have installed. 
+
 
 ## Deploying the OpenCue sandbox environment
 

--- a/content/docs/Quick starts/quick-start-linux.md
+++ b/content/docs/Quick starts/quick-start-linux.md
@@ -27,6 +27,7 @@ You must have the following software installed on your machine:
 *   Python version 2.7 or greater
 *   The Python [`pip` command](https://pypi.org/project/pip/)
 *   The Python [virtualenv tool](https://pypi.org/project/virtualenv/)
+*   The ```python-dev``` [command](https://pypi.org/project/Python-dev/)
 *   [Docker](https://docs.docker.com/install/)
 *   [Docker Compose](https://docs.docker.com/compose/install/)
 

--- a/content/docs/Quick starts/quick-start-linux.md
+++ b/content/docs/Quick starts/quick-start-linux.md
@@ -27,7 +27,8 @@ You must have the following software installed on your machine:
 *   Python version 2.7 or greater
 *   The Python [`pip` command](https://pypi.org/project/pip/)
 *   The Python [virtualenv tool](https://pypi.org/project/virtualenv/)
-*   The ```python-dev``` (Ubuntu/Debian) or ```python-devel```(Fedora/Cent-OS) package 
+*   If you're using Ubuntu or Debian, the `python-dev` package
+*   If you're using Fedora or Cent-OS, the `python-devel` package
 *   [Docker](https://docs.docker.com/install/)
 *   [Docker Compose](https://docs.docker.com/compose/install/)
 


### PR DESCRIPTION
While setting up a local instance using the Linux quickstart page, the ```python-dev``` dependency is missing from the list of pre-requisites which is needed. This PR adds the ```python-dev``` dependency to the documentation.