### PR TITLE
List pycue as next step after deploying RQD.

### DIFF
--- a/content/docs/Getting started/deploying-rqd.md
+++ b/content/docs/Getting started/deploying-rqd.md
@@ -164,5 +164,4 @@ started up:
 
 ## What's next?
 
-*   [Checking out the source
-    code](/docs/getting-started/checking-out-the-source-code)
+*   [Installing PyCue and PyOutline](/docs/getting-started/installing-pycue-and-pyoutline)


### PR DESCRIPTION
It's not necessary to check out the source unless you're installing some component from source instead of using a published release, which most users probably aren't doing. Making someone install and use git when they might not be familiar with it creates a hurdle which could discourage less technical users.

The Python component pages send folks back to "Checking out the source code" as a prerequisite if it's actually needed.