### PR TITLE
Remove -m option from grpcio-tool install command on Linux

### DIFF
--- a/content/contributing/opencue/Getting started/getting-started-linux.md
+++ b/content/contributing/opencue/Getting started/getting-started-linux.md
@@ -241,7 +241,7 @@ currently a manual process. To generate the Python code:
 1. Install the required gRPC tools:
 
     ```shell
-    pip -m install grpcio-tools
+    pip install grpcio-tools
     ```
 
 1. Change directory to the `proto` folder.


### PR DESCRIPTION
**Link the issue(s) this pull request is related to.**
https://github.com/AcademySoftwareFoundation/opencue.io/issues/256

**Summarize your change.**
Updated the gRPC installation command on Linux.

The earlier command included a `-m` option that resulted in an error.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.
-->
