### PR TITLE
Update docs for when RQD container is run locally

### DIFF
--- a/content/docs/Getting started/deploying-rqd.md
+++ b/content/docs/Getting started/deploying-rqd.md
@@ -84,7 +84,7 @@ To download and run the pre-built Docker image from DockerHub:
 
 ```shell
 docker pull opencue/rqd
-docker run -td --name rqd01 --env CUEBOT_HOSTNAME=${CUEBOT_HOSTNAME} --volume "${CUE_FS_ROOT}:${CUE_FS_ROOT}" opencue/rqd
+docker run -td --name rqd01 --env CUEBOT_HOSTNAME=${CUEBOT_HOSTNAME} --volume "${CUE_FS_ROOT}:${CUE_FS_ROOT}" --add-host host.docker.internal:host-gateway opencue/rqd
 ```
 
 ### Option 2: Building and running RQD from source
@@ -93,14 +93,14 @@ To build and run the RQD Docker image from source:
 
 ```shell
 docker build -t opencue/rqd -f rqd/Dockerfile .
-docker run -td --name rqd01 --env CUEBOT_HOSTNAME=${CUEBOT_HOSTNAME} --volume "${CUE_FS_ROOT}:${CUE_FS_ROOT}" opencue/rqd
+docker run -td --name rqd01 --env CUEBOT_HOSTNAME=${CUEBOT_HOSTNAME} --volume "${CUE_FS_ROOT}:${CUE_FS_ROOT}" --add-host host.docker.internal:host-gateway opencue/rqd
 ```
 
--   **In both Option 1 and 2**, if running the RQD container in your local machine, use the `--add-host` flag on the `docker run` command as follows:
+<!-- -   **In both Option 1 and 2**, if running the RQD container in your local machine, use the `--add-host` flag on the `docker run` command as follows:
 
     ```shell
     docker run -td --name rqd01 --env CUEBOT_HOSTNAME=${CUEBOT_HOSTNAME} --volume "${CUE_FS_ROOT}:${CUE_FS_ROOT}" --add-host host.docker.internal:host-gateway opencue/rqd
-    ```
+    ``` -->
 
 ### Option 3: Installing from the published release
 

--- a/content/docs/Getting started/deploying-rqd.md
+++ b/content/docs/Getting started/deploying-rqd.md
@@ -42,18 +42,18 @@ Make sure you also complete the following steps:
         export CUEBOT_HOSTNAME=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' cuebot)
         ```
 
+        **If the Cuebot container is running locally in your machine**,
+    use the Docker API to specify the container IP.
+
+        ```shell
+        export CUEBOT_HOSTNAME=host.docker.internal
+        ```
+
     -   **If your Cuebot is running on a different machine**, use that machine's
         hostname or IP:
 
         ```shell
         export CUEBOT_HOSTNAME=<hostname or IP of the Cuebot machine>
-        ```
-
-    -   **If your Cuebot is running locally in your development machine**,
-    use the Docker API to specify the container IP.
-
-        ```shell
-        export CUEBOT_HOSTNAME=host.docker.internal
         ```
 
 1.  RQD needs access to the filesystem where render assets are stored and log

--- a/content/docs/Getting started/deploying-rqd.md
+++ b/content/docs/Getting started/deploying-rqd.md
@@ -49,6 +49,13 @@ Make sure you also complete the following steps:
         export CUEBOT_HOSTNAME=<hostname or IP of the Cuebot machine>
         ```
 
+    -   **If your Cuebot is running locally in your development machine**,
+    use the Docker API to specify the container IP.
+
+        ```shell
+        export CUEBOT_HOSTNAME=host.docker.internal
+        ```
+
 1.  RQD needs access to the filesystem where render assets are stored and log
     files are written. In a large-scale deployment a shared filesystem such as
     NFS is often used for this purpose.
@@ -88,6 +95,12 @@ To build and run the RQD Docker image from source:
 docker build -t opencue/rqd -f rqd/Dockerfile .
 docker run -td --name rqd01 --env CUEBOT_HOSTNAME=${CUEBOT_HOSTNAME} --volume "${CUE_FS_ROOT}:${CUE_FS_ROOT}" opencue/rqd
 ```
+
+-   **In both Option 1 and 2**, if running the RQD container in your local development machine, use the `--add-host` flag on the `docker run` command as follows:
+
+    ```shell
+    docker run -td --name rqd01 --env CUEBOT_HOSTNAME=${CUEBOT_HOSTNAME} --volume "${CUE_FS_ROOT}:${CUE_FS_ROOT}" --add-host host.docker.internal:host-gateway opencue/rqd
+    ```
 
 ### Option 3: Installing from the published release
 

--- a/content/docs/Getting started/deploying-rqd.md
+++ b/content/docs/Getting started/deploying-rqd.md
@@ -42,8 +42,8 @@ Make sure you also complete the following steps:
         export CUEBOT_HOSTNAME=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' cuebot)
         ```
 
-        **If the Cuebot container is running locally in your machine**,
-    use the Docker API to specify the container IP.
+         **If RQD is running locally in your machine in a container**,
+    use the Docker API to map the host IP.
 
         ```shell
         export CUEBOT_HOSTNAME=host.docker.internal

--- a/content/docs/Getting started/deploying-rqd.md
+++ b/content/docs/Getting started/deploying-rqd.md
@@ -96,7 +96,7 @@ docker build -t opencue/rqd -f rqd/Dockerfile .
 docker run -td --name rqd01 --env CUEBOT_HOSTNAME=${CUEBOT_HOSTNAME} --volume "${CUE_FS_ROOT}:${CUE_FS_ROOT}" opencue/rqd
 ```
 
--   **In both Option 1 and 2**, if running the RQD container in your local development machine, use the `--add-host` flag on the `docker run` command as follows:
+-   **In both Option 1 and 2**, if running the RQD container in your local machine, use the `--add-host` flag on the `docker run` command as follows:
 
     ```shell
     docker run -td --name rqd01 --env CUEBOT_HOSTNAME=${CUEBOT_HOSTNAME} --volume "${CUE_FS_ROOT}:${CUE_FS_ROOT}" --add-host host.docker.internal:host-gateway opencue/rqd


### PR DESCRIPTION
**Link the issue(s) this pull request is related to.**
Related to the gRPC connection issue as mentioned in:  https://github.com/AcademySoftwareFoundation/OpenCue/issues/1301#issuecomment-1666116478.
Discussed further in this mail thread: https://lists.aswf.io/g/opencue-dev/topic/100605668#660

**Summarize your change.**
Updates the `CUEBOT_HOSTNAME` field and adds a flag to the `docker run` command when RQD container is being run in the local development machine

