### PR TITLE
Add docs for sample RQD CUDA Dockerfile

### DIFF
--- a/content/docs/Getting started/deploying-rqd.md
+++ b/content/docs/Getting started/deploying-rqd.md
@@ -165,3 +165,4 @@ started up:
 ## What's next?
 
 *   [Installing PyCue and PyOutline](/docs/getting-started/installing-pycue-and-pyoutline)
+*   [Customizing RQD rendering hosts](/docs/other-guides/customizing-rqd) 

--- a/content/docs/Other guides/customizing-rqd.md
+++ b/content/docs/Other guides/customizing-rqd.md
@@ -50,7 +50,7 @@ To view the sample `Dockerfiles`:
 
 The sample `Dockerfiles` are listed within their respective subdirectories.
 
-### Reviewing sample Blender Dockerfile
+### Reviewing the sample Blender Dockerfile
 
 The sample Blender `Dockerfile` showcases the Blender installation process and environment variable setup.
 You can update the sandbox environment to build and run the sample `Dockerfile` so that you can submit and run a rendering job using Blender than just the basic command-line tools illustrated in the quick start. 
@@ -129,7 +129,7 @@ If you'd like to learn more about the configuration of the default
 [`rqd/Dockerfile`](https://github.com/AcademySoftwareFoundation/OpenCue/blob/master/rqd/Dockerfile)
 in the `master` branch on GitHub.
 
-### Reviewing sample CUDA Dockerfile
+### Reviewing the sample CUDA Dockerfile
 
 The sample CUDA Dockerfile extends the default RQD container image to support GPU rendering on supported Nvidia Hardware. This requires Nvidia [Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html#installing-with-apt) to be installed on render nodes as a prerequisite.
 

--- a/content/docs/Other guides/customizing-rqd.md
+++ b/content/docs/Other guides/customizing-rqd.md
@@ -24,7 +24,7 @@ also need all of the software and source code you used in the quick start.
 
 ## Sample Dockerfiles
 
-The Opencue project includes [sample](https://github.com/AcademySoftwareFoundation/OpenCue/tree/master/samples/rqd/) `Dockerfiles` to illustrate how to install
+The OpenCue project includes [sample](https://github.com/AcademySoftwareFoundation/OpenCue/tree/master/samples/rqd/) `Dockerfiles` to illustrate how to install
 additional software for RQD containers. 
 OpenCue currently includes sample Dockerfiles showcasing the following:
 
@@ -68,77 +68,77 @@ You can update the sandbox environment to build and run the sample `Dockerfile` 
 
 Before you update the sandbox to run the sample `Dockerfile`, you might find it useful to review the source code for the sample container.
 
-    Run the following command to review the sample `Dockerfile`:
+Run the following command to review the sample `Dockerfile`:
 
-    ```bash
-    cat blender/Dockerfile
-    ```
-    The command outputs the contents of the Dockerfile.
-    
-    The first section of the file indicates that this `Dockerfile`
-    builds on the basic `opencue/rqd` container image hosted on
-    Docker Hub:
+```bash
+cat blender/Dockerfile
+```
+The command outputs the contents of the Dockerfile.
 
-    ```Dockerfile
-    # Builds on the latest base image of RQD from Docker Hub
-    FROM opencue/rqd
-    ```
+The first section of the file indicates that this `Dockerfile`
+builds on the basic `opencue/rqd` container image hosted on
+Docker Hub:
 
-    The next section installs all of the dependencies required
-    to run Blender 2.79 on the CentOS operating system installed in the
-    `opencue/rqd` container image:
+```Dockerfile
+# Builds on the latest base image of RQD from Docker Hub
+FROM opencue/rqd
+```
 
-    ```Dockerfile
-    # Install dependencies to run Blender on the opencue/rqd image
-    RUN yum -y update
-    RUN yum -y install \
-            bzip2 \
-            libfreetype6 \
-            libgl1-mesa-dev \
-            libXi-devel  \
-            mesa-libGLU-devel \
-            zlib-devel \
-            libXinerama-devel \
-            libXrandr-devel
-    ```
+The next section installs all of the dependencies required
+to run Blender 2.79 on the CentOS operating system installed in the
+`opencue/rqd` container image:
 
-    The next section sets up parameters for the Blender installation directory and download source.
+```Dockerfile
+# Install dependencies to run Blender on the opencue/rqd image
+RUN yum -y update
+RUN yum -y install \
+        bzip2 \
+        libfreetype6 \
+        libgl1-mesa-dev \
+        libXi-devel  \
+        mesa-libGLU-devel \
+        zlib-devel \
+        libXinerama-devel \
+        libXrandr-devel
+```
 
-    ```Dockerfile
-    # Set Blender install directory
-    ARG BLENDER_INSTALL_DIR=/usr/local/blender
+The next section sets up parameters for the Blender installation directory and download source.
 
-    # Set Blender download source
-    ARG BLENDER_DOWNLOAD_SRC=https://download.blender.org/release/Blender3.3/blender-3.3.3-linux-x64.tar.xz
-    ```
-    
-    The final section downloads and extracts the archive for Blender
-    to the provided installation directory, in this case `/usr/local/blender`.:
+```Dockerfile
+# Set Blender install directory
+ARG BLENDER_INSTALL_DIR=/usr/local/blender
 
-    ```Dockerfile
-    # Download and install Blender
-    RUN mkdir ${BLENDER_INSTALL_DIR}
-    RUN curl -SL ${BLENDER_DOWNLOAD_SRC} \
-            -o blender.tar.xz
+# Set Blender download source
+ARG BLENDER_DOWNLOAD_SRC=https://download.blender.org/release/Blender3.3/blender-3.3.3-linux-x64.tar.xz
+```
 
-    RUN tar -xvf blender.tar.xz \
-            -C ${BLENDER_INSTALL_DIR} \
-            --strip-components=1
+The final section downloads and extracts the archive for Blender
+to the provided installation directory, in this case `/usr/local/blender`.:
 
-    RUN rm blender.tar.xz
-    ```
+```Dockerfile
+# Download and install Blender
+RUN mkdir ${BLENDER_INSTALL_DIR}
+RUN curl -SL ${BLENDER_DOWNLOAD_SRC} \
+        -o blender.tar.xz
 
-    The final command verifies the Blender installation.
+RUN tar -xvf blender.tar.xz \
+        -C ${BLENDER_INSTALL_DIR} \
+        --strip-components=1
 
-    ```Dockerfile
-    # Verify Blender installation
-    RUN ${BLENDER_INSTALL_DIR}/blender --version
-    ```
+RUN rm blender.tar.xz
+```
 
-    If you'd like to learn more about the configuration of the default
-    `opencue/rqd` container image, view the source code for
-    [`rqd/Dockerfile`](https://github.com/AcademySoftwareFoundation/OpenCue/blob/master/rqd/Dockerfile)
-    in the `master` branch on GitHub.
+The final command verifies the Blender installation.
+
+```Dockerfile
+# Verify Blender installation
+RUN ${BLENDER_INSTALL_DIR}/blender --version
+```
+
+If you'd like to learn more about the configuration of the default
+`opencue/rqd` container image, view the source code for
+[`rqd/Dockerfile`](https://github.com/AcademySoftwareFoundation/OpenCue/blob/master/rqd/Dockerfile)
+in the `master` branch on GitHub.
 
 ### Reviewing sample CUDA Dockerfile
 

--- a/content/docs/Other guides/customizing-rqd.md
+++ b/content/docs/Other guides/customizing-rqd.md
@@ -22,17 +22,16 @@ through the steps in this guide, make sure you have successfully started the
 OpenCue sandbox environment and run a basic command-line test job. You'll
 also need all of the software and source code you used in the quick start.
 
-## Reviewing a sample Dockerfile
+## Sample Dockerfiles
 
-The Opencue project includes a sample `Dockerfile` to illustrate how to install
-additional software for RQD containers. You can update the sandbox environment
-to build and run the sample `Dockerfile` so that you can submit and run a
-rendering job using Blender than just the basic command-line tools illustrated
-in the quick start. Before you update the sandbox to run the sample
-`Dockerfile`, you might find it useful to review the source code for the
-sample container.
+The Opencue project includes [sample](https://github.com/AcademySoftwareFoundation/OpenCue/tree/master/samples/rqd/) `Dockerfiles` to illustrate how to install
+additional software for RQD containers. 
+OpenCue currently includes sample Dockerfiles showcasing the following:
 
-To review the sample `Dockerfile`:
+- [Blender](https://www.blender.org/) installation
+- [Nvidia CUDA](https://developer.nvidia.com/cuda-toolkit) installation for GPU accellerated rendering
+
+To view the sample `Dockerfiles`:
 
 1.  Open a terminal.
 
@@ -43,15 +42,39 @@ To review the sample `Dockerfile`:
     ```bash
     cd ~/OpenCue
     ```
-
-1.  Run the following command to review the sample `Dockerfile`:
+1. Change to the subdirectory which includes the sample `Dockerfiles`.
 
     ```bash
-    cat samples/rqd/blender/Dockerfile
+    cd samples/rqd
     ```
 
-    The command outputs the contents of the `Dockerfile`.
+The sample `Dockerfiles` are listed within their respective subdirectories.
 
+<!-- 1.  Run the following command to review the sample `Dockerfile`:
+
+    ```bash
+    # For the sample Blender Dockerfile
+    cat blender/Dockerfile
+    # For the sample Nvidia CUDA Dockerfile
+    cat cuda/Dockerfile
+    ```
+
+    The command outputs the contents of the `Dockerfile`. -->
+
+### Reviewing sample Blender Dockerfile
+
+The sample Blender `Dockerfile` showcases the Blender installation process and environment variable setup.
+You can update the sandbox environment to build and run the sample `Dockerfile` so that you can submit and run a rendering job using Blender than just the basic command-line tools illustrated in the quick start. 
+
+Before you update the sandbox to run the sample `Dockerfile`, you might find it useful to review the source code for the sample container.
+
+    Run the following command to review the sample `Dockerfile`:
+
+    ```bash
+    cat blender/Dockerfile
+    ```
+    The command outputs the contents of the Dockerfile.
+    
     The first section of the file indicates that this `Dockerfile`
     builds on the basic `opencue/rqd` container image hosted on
     Docker Hub:
@@ -116,6 +139,18 @@ To review the sample `Dockerfile`:
     `opencue/rqd` container image, view the source code for
     [`rqd/Dockerfile`](https://github.com/AcademySoftwareFoundation/OpenCue/blob/master/rqd/Dockerfile)
     in the `master` branch on GitHub.
+
+### Reviewing sample CUDA Dockerfile
+
+The sample CUDA Dockerfile extends the default RQD container image to support GPU rendering on supported Nvidia Hardware. This requires Nvidia [Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html#installing-with-apt) to be installed on render nodes as a prerequisite.
+
+    Run the following command to review the sample `Dockerfile`:
+
+    ```bash
+    cat cuda/Dockerfile
+    ```
+    The command outputs the contents of the Dockerfile.
+
 
 ## Updating the sandbox environment
 

--- a/content/docs/Other guides/customizing-rqd.md
+++ b/content/docs/Other guides/customizing-rqd.md
@@ -50,17 +50,6 @@ To view the sample `Dockerfiles`:
 
 The sample `Dockerfiles` are listed within their respective subdirectories.
 
-<!-- 1.  Run the following command to review the sample `Dockerfile`:
-
-    ```bash
-    # For the sample Blender Dockerfile
-    cat blender/Dockerfile
-    # For the sample Nvidia CUDA Dockerfile
-    cat cuda/Dockerfile
-    ```
-
-    The command outputs the contents of the `Dockerfile`. -->
-
 ### Reviewing sample Blender Dockerfile
 
 The sample Blender `Dockerfile` showcases the Blender installation process and environment variable setup.
@@ -144,12 +133,12 @@ in the `master` branch on GitHub.
 
 The sample CUDA Dockerfile extends the default RQD container image to support GPU rendering on supported Nvidia Hardware. This requires Nvidia [Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html#installing-with-apt) to be installed on render nodes as a prerequisite.
 
-    Run the following command to review the sample `Dockerfile`:
+Run the following command to review the sample `Dockerfile`:
 
-    ```bash
-    cat cuda/Dockerfile
-    ```
-    The command outputs the contents of the Dockerfile.
+```bash
+cat cuda/Dockerfile
+```
+The command outputs the contents of the Dockerfile.
 
 
 ## Updating the sandbox environment


### PR DESCRIPTION
**Link the issue(s) this pull request is related to.**
Related to OpenCue PR [#1327](https://github.com/AcademySoftwareFoundation/OpenCue/pull/1327) as discussed [here](https://github.com/AcademySoftwareFoundation/OpenCue/pull/1327#issuecomment-1804787415).


**Summarize your change.**
Adds new **Sample Dockerfiles** section to the [**Customizing RQD**](https://www.opencue.io/docs/other-guides/customizing-rqd/#reviewing-a-sample-dockerfile) page and appends the CUDA Dockerfile docs as a subsection. 
Also converts the existing **[Reviewing a sample Dockerfile](https://www.opencue.io/docs/other-guides/customizing-rqd/#reviewing-a-sample-dockerfile)** section to a subsection within **Sample Dockerfiles** for a better flow.

Keeping PR as a draft until the Dockerfile gets finalized.