### PR TITLE
Add a link to the confluence page

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -13,6 +13,9 @@ linkTitle = "OpenCue"
 	<a class="btn btn-lg btn-dark mr-3 mt-3 ml-3 mb-5" href="https://github.com/AcademySoftwareFoundation/OpenCue">
 		Contribute <i class="fab fa-github ml-1"></i>
 	</a>
+	<a class="btn btn-lg btn-primary mr-3 mt-3 ml-3 mb-5" href="https://wiki.aswf.io/display/OPENCUE/OpenCue+Home">
+		Participate <i class="fab fa-confluence ml-1"></i>
+	</a>
 	<div class="w-75 mx-auto embed-responsive embed-responsive-16by9 mb-3">
 		<iframe class="embed-responsive-item" width="560" height="315" src="https://www.youtube-nocookie.com/embed/jPpBcHCMlA4" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 	</div>


### PR DESCRIPTION
Meeting notes and general Wiki content has been migrated to confluence. Adding a link to the home page to make people aware of the page existence.
