### PR TITLE
Fix containerized_frames README file weight

### DIFF
--- a/content/docs/Other guides/containerized_frames.md
+++ b/content/docs/Other guides/containerized_frames.md
@@ -1,7 +1,7 @@
 ---
 title: "Running RQD at Docker mode"
 linkTitle: "Running RQD at Docker mode"
-weight: 3
+weight: 8
 date: 2024-11-06
 description: >
   Running rqd with docker mode so that each frame is launched


### PR DESCRIPTION
Fix the `containerized_frames.md` README file weight. The correct is `weight: 8`, not `weight: 3`, following the last weight: 7 in the file [Monitoring with Prometheus, Loki, and Grafana](https://github.com/AcademySoftwareFoundation/opencue.io/edit/master/content/docs/Other%20guides/monitoring-with-prometheus-loki-and-grafana.md).

After fixing that the new page `Fix containerized_frames README file weight` will be displayed in the opencue.io.